### PR TITLE
ブランチ名のタイポ修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
   push:
     branches:
-      - develop
+      - development
 
   #手動実行
   workflow_dispatch:


### PR DESCRIPTION
.github/workflows/ci.ymlのブランチ名をdevelopからdevelopmentに変更